### PR TITLE
ovirtsdk backend: use list to retrieve VM by name

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -65,9 +65,9 @@ class RHEVM(VirtBackend):
 
     def get_vm(self, name, attempts=4):
         for i in range(attempts):
-            vm = self.api.vms.get(name)
-            if vm:
-                return vm
+            vms = self.api.vms.list(name=name)
+            if vms:
+                return vms[0]
         raise ValueError('Given VM name %s does not exist' % name)
 
     def get_ips(self, name):


### PR DESCRIPTION
Ovirtsdk API no longer allows to retrieve VMs by name using
api.vms.get(). This workaround uses the list() method to retrieve
VMs by their name.

---

I'm not sure if this is intended change in ovirtsdk or just a temporary bug, but nevertheless - currently `api.vms.get(VM_NAME)` does not work. I'm just sharing this in case anyone else runs into the same issue.